### PR TITLE
Closes #40 - Return user info upon sign in and sign up

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -26,14 +26,14 @@ export class AuthController {
   @Public()
   @Post('local/signup')
   @HttpCode(HttpStatus.CREATED)
-  signup_local(@Body() createUserDto: CreateUserDto): Promise<Tokens> {
+  signup_local(@Body() createUserDto: CreateUserDto) {
     return this.authService.signup_local(createUserDto);
   }
 
   @Public()
   @Post('local/signin')
   @HttpCode(HttpStatus.OK)
-  signin_local(@Body() authDto: AuthDto): Promise<Tokens> {
+  signin_local(@Body() authDto: AuthDto) {
     return this.authService.signin_local(authDto);
   }
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -20,16 +20,16 @@ export class AuthService {
   ) {}
 
   //DB CHANGES
-  async signup_local(userInfo: CreateUserDto): Promise<Tokens> {
+  async signup_local(userInfo: CreateUserDto) {
     const new_user = await this.userService.create(userInfo);
 
     const tokens = await this.getTokens(new_user.id, new_user.email);
     await this.updateRtHash(new_user.id, tokens.refresh_token);
 
-    return tokens;
+    return { user: new_user, tokens };
   }
 
-  async signin_local(authInfo: AuthDto): Promise<Tokens> {
+  async signin_local(authInfo: AuthDto) {
     const user = await this.userService.findOneByEmail(authInfo.email);
 
     if (!user) throw new LoginFailedException();
@@ -42,7 +42,7 @@ export class AuthService {
     const tokens = await this.getTokens(user.id, user.email);
     await this.updateRtHash(user.id, tokens.refresh_token);
 
-    return tokens;
+    return { user, tokens };
   }
 
   async logout(userId: string) {

--- a/src/models/user/user.service.ts
+++ b/src/models/user/user.service.ts
@@ -28,10 +28,16 @@ export class UserService {
         createUserDto.accessibilities
       );
       user.accessibilities = accessibility;
-      accessibility.user = user;
+      // accessibility.user = user;
       await this.accessibilityRepository.save(accessibility);
       const saved = await this.usersRepository.save(user);
       delete saved.password;
+      delete saved.createdAt;
+      delete saved.updatedAt;
+      delete saved.hashedRefreshToken;
+      delete saved.accessibilities.id;
+      delete saved.accessibilities.updatedAt;
+      delete saved.accessibilities.createdAt;
       return saved;
     } catch (error) {
       throw new UnauthorizedException('E-mail already in use. Try to login');


### PR DESCRIPTION
Closes #40 

# Overview:
- Now upon successful request at /auth/local/signin and /auth/local/signup, the user info + accessibility are return alongside its tokens

# Routes changed:
- /auth/local
      - /signin
      - /signup